### PR TITLE
fix top and bottom of the cape

### DIFF
--- a/Shared/src/main/java/dev/tr7zw/waveycapes/renderlayers/CustomCapeRenderLayer.java
+++ b/Shared/src/main/java/dev/tr7zw/waveycapes/renderlayers/CustomCapeRenderLayer.java
@@ -438,18 +438,13 @@ public class CustomCapeRenderLayer extends RenderLayer<AbstractClientPlayer, Pla
         float minV = 0;
         float maxV = .03125F;
 
-        float deltaV = maxV - minV;
-        float vPerPart = deltaV / partCount;
-        maxV = minV + (vPerPart * (part + 1));
-        minV = minV + (vPerPart * part);
-
-        bufferBuilder.vertex(oldMatrix, x1, y2, z2).color(1f, 1f, 1f, 1f).uv(maxU, minV)
+        bufferBuilder.vertex(oldMatrix, x1, y2, z2).color(1f, 1f, 1f, 1f).uv(maxU, maxV)
                 .overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(1, 0, 0).endVertex();
-        bufferBuilder.vertex(oldMatrix, x2, y2, z2).color(1f, 1f, 1f, 1f).uv(minU, minV)
+        bufferBuilder.vertex(oldMatrix, x2, y2, z2).color(1f, 1f, 1f, 1f).uv(minU, maxV)
                 .overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(1, 0, 0).endVertex();
-        bufferBuilder.vertex(matrix, x2, y1, z1).color(1f, 1f, 1f, 1f).uv(minU, maxV)
+        bufferBuilder.vertex(matrix, x2, y1, z1).color(1f, 1f, 1f, 1f).uv(minU, minV)
                 .overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(1, 0, 0).endVertex();
-        bufferBuilder.vertex(matrix, x1, y1, z1).color(1f, 1f, 1f, 1f).uv(maxU, maxV)
+        bufferBuilder.vertex(matrix, x1, y1, z1).color(1f, 1f, 1f, 1f).uv(maxU, minV)
                 .overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(1, 0, 0).endVertex();
     }
 
@@ -474,18 +469,13 @@ public class CustomCapeRenderLayer extends RenderLayer<AbstractClientPlayer, Pla
         float minV = 0;
         float maxV = .03125F;
 
-        float deltaV = maxV - minV;
-        float vPerPart = deltaV / partCount;
-        maxV = minV + (vPerPart * (part + 1));
-        minV = minV + (vPerPart * part);
-
-        bufferBuilder.vertex(oldMatrix, x1, y2, z1).color(1f, 1f, 1f, 1f).uv(maxU, maxV)
+        bufferBuilder.vertex(oldMatrix, x1, y2, z1).color(1f, 1f, 1f, 1f).uv(maxU, minV)
                 .overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(0, 1, 0).endVertex();
-        bufferBuilder.vertex(oldMatrix, x2, y2, z1).color(1f, 1f, 1f, 1f).uv(minU, maxV)
+        bufferBuilder.vertex(oldMatrix, x2, y2, z1).color(1f, 1f, 1f, 1f).uv(minU, minV)
                 .overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(0, 1, 0).endVertex();
-        bufferBuilder.vertex(matrix, x2, y1, z2).color(1f, 1f, 1f, 1f).uv(minU, minV)
+        bufferBuilder.vertex(matrix, x2, y1, z2).color(1f, 1f, 1f, 1f).uv(minU, maxV)
                 .overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(0, 1, 0).endVertex();
-        bufferBuilder.vertex(matrix, x1, y1, z2).color(1f, 1f, 1f, 1f).uv(maxU, minV)
+        bufferBuilder.vertex(matrix, x1, y1, z2).color(1f, 1f, 1f, 1f).uv(maxU, maxV)
                 .overlayCoords(OverlayTexture.NO_OVERLAY).uv2(light).normal(0, 1, 0).endVertex();
     }
 


### PR DESCRIPTION
Fixes the following things:
- the top and bottom textures are glitchy when the cape texture is high-res
- top and bottom textures are mirrored