### PR TITLE
Fix cape misalignment in non-Classic movement modes (#143)

### DIFF
--- a/src/main/java/dev/tr7zw/waveycapes/renderlayers/CustomCapeRenderLayer.java
+++ b/src/main/java/dev/tr7zw/waveycapes/renderlayers/CustomCapeRenderLayer.java
@@ -1,12 +1,8 @@
 package dev.tr7zw.waveycapes.renderlayers;
 
 import com.mojang.blaze3d.vertex.PoseStack;
-import dev.tr7zw.transition.mc.*;
 import dev.tr7zw.transition.mc.entitywrapper.PlayerWrapper;
 import dev.tr7zw.waveycapes.WaveyCapesBase;
-
-import dev.tr7zw.waveycapes.versionless.*;
-import dev.tr7zw.waveycapes.versionless.util.*;
 import net.minecraft.client.Minecraft;
 //? if >= 1.21.11 {
 
@@ -15,7 +11,6 @@ import net.minecraft.client.model.player.*;
 
 /*import net.minecraft.client.model.*;
 *///? }
-import net.minecraft.client.renderer.debug.*;
 import net.minecraft.client.renderer.entity.RenderLayerParent;
 import net.minecraft.client.renderer.entity.layers.RenderLayer;
 
@@ -23,10 +18,6 @@ import net.minecraft.client.renderer.entity.layers.RenderLayer;
 
 import net.minecraft.client.renderer.entity.state.AvatarRenderState;
 import net.minecraft.client.renderer.SubmitNodeCollector;
-import net.minecraft.world.phys.*;
-import org.joml.*;
-
-import java.lang.Math;
 //? } else {
 
 /*import net.minecraft.client.renderer.MultiBufferSource;
@@ -112,45 +103,7 @@ public class CustomCapeRenderLayer
             poseStack.translate(0.0F, -0.053125F, 0.06875F);
         }
 
-        var bodyPos = MathUtil.getWorldSpacePosition(poseStack.last().pose());
-
-        poseStack.pushPose();
-        poseStack.translate(0.0F, 1.0F, 0);
-        var upPos = MathUtil.getWorldSpacePosition(poseStack.last().pose());
-        poseStack.popPose();
-
-        //net.minecraft.gizmos.Gizmos.line(bodyPos.add(1, 1, 1), upPos.add(1, 1, 1), 0xFF00FF00, 10.0F);
-        var orientation = upPos.subtract(bodyPos).normalize();
-        // remove the players yaw from the orientation vector, so the cape is not affected by the players yaw
-        //? if >= 1.21.9 {
-
-        float bodyYRot = capeRenderInfo.getAvatar().yBodyRot - 90;
-        //? } else {
-        /*float bodyYRot = capeRenderInfo.getEntity().yBodyRot - 90;
-         *///? }
-        var relativeOrientation = new Vector3(
-                (float) (orientation.x() * Mth.cos(-bodyYRot * MathUtil.DEG_TO_RAD)
-                        - orientation.z() * Mth.sin(-bodyYRot * MathUtil.DEG_TO_RAD)),
-                (float) orientation.y(), (float) (orientation.x() * Mth.sin(-bodyYRot * MathUtil.DEG_TO_RAD)
-                        + orientation.z() * Mth.cos(-bodyYRot * MathUtil.DEG_TO_RAD)));
-        /*
-        net.minecraft.gizmos.Gizmos.line(bodyPos.add(-1, 1, -1),
-                bodyPos.add(-1 + relativeOrientation.x, 1 + relativeOrientation.y, -1 + relativeOrientation.z),
-                0xFFFFFF00, 10.0F);
-         */
-
-        //? if >= 1.21.9 {
-
-        if (capeRenderInfo.getAvatar() instanceof CapeHolder capeHolder) {
-            //? } else {
-            /*        if (capeRenderInfo.getEntity() instanceof CapeHolder capeHolder) {
-             *///? }
-            var simulation = capeHolder.getSimulation();
-            if (simulation != null) {
-                simulation.setGravityDirection(relativeOrientation);
-            }
-        }
-
+        // gravity direction is fixed body-relative down, no need to derive it from the pose each frame
         //? if >= 1.21.9 {
 
         WaveyCapesBase.INSTANCE.getCapeNodeCollector().submitCape(submitNodeCollector, capeRenderInfo, poseStack,


### PR DESCRIPTION
  ## Problem

  Since 1.11.0, the cape becomes visibly misaligned/pinned sideways when
  Cape Movement is set to a non-Classic mode (both in-world and in the
  inventory preview). Classic mode is unaffected. Downgrading to 1.10.2
  fixes it.

  ## Root cause

  A commit added per-frame gravity-direction computation in
  `CustomCapeRenderLayer`, derived from the render pose matrix: it took
  the world-space "up" vector from the pose and un-rotated it by the
  player's body yaw, then pushed that into the simulation via
  `setGravityDirection()` every frame.

  This was fragile:
  - Mismatch between the pose's interpolated `bodyRot` and the raw
    `yBodyRot` used to un-rotate it produced a horizontal gravity
    vector, pinning the cape out sideways.
  - Degenerate poses collapsed the vector to zero via
    `Vec3.normalize()`, leaving the cape frozen with no restoring force.

  Classic mode doesn't run the physics simulation at all, so it was
  never affected.

  ## Fix

  The simulation already works entirely in body-relative space, where
  "down" is always `(0,-1,0)` (`StickSimulation3d`'s default). There was
  no need to derive it from the pose each frame, so that computation is
  removed and the default gravity direction is used as-is.

  ## Testing

  - Built `:26.2-fabric:build`, verified compile succeeds.
  - Manually tested cape alignment on 26.2-fabric in-world and in the
    inventory preview across Cape Movement modes.

  Fixes #143